### PR TITLE
Added tests for GetSongs etc with search queries+correct repo methods

### DIFF
--- a/MusicAPI/Handlers/APIArtistHandler.cs
+++ b/MusicAPI/Handlers/APIArtistHandler.cs
@@ -17,7 +17,7 @@ namespace MusicAPI.Handlers
             }
             catch (Exception ex)
             {
-                return Results.BadRequest($"Unable to add artist {ex.Message}");
+                return Results.BadRequest(new { Error = $"Unable to add artist: {ex.Message}" });
             }
             return Results.StatusCode((int)HttpStatusCode.Created);
         }
@@ -29,7 +29,7 @@ namespace MusicAPI.Handlers
             }
             catch (Exception ex)
             {
-                return Results.BadRequest($"Unable to add song {ex.Message}");
+                return Results.BadRequest(new { Error = $"Unable to add song: {ex.Message}" });
             }
             return Results.StatusCode((int)HttpStatusCode.Created);
         }
@@ -41,7 +41,7 @@ namespace MusicAPI.Handlers
             }
             catch (Exception ex)
             {
-                return Results.BadRequest($"Unable to add genre {ex.Message}");
+                return Results.BadRequest(new { Error = $"Unable to add genre: {ex.Message}" });
             }
             return Results.StatusCode((int)HttpStatusCode.Created);
         }
@@ -53,7 +53,7 @@ namespace MusicAPI.Handlers
             }
             catch (Exception ex)
             {
-                return Results.BadRequest(new {Message =$"Unable to get artists: {ex.Message}" });
+                return Results.BadRequest(new { Error = $"Unable to get artists: {ex.Message}" });
             }
             return Results.Json(artistRepo.GetArtistsForUser(username));
         }
@@ -65,7 +65,7 @@ namespace MusicAPI.Handlers
             }
             catch (Exception ex)
             {
-                return Results.BadRequest($"Unable to get genres: {ex.Message}");
+                return Results.BadRequest(new { Error = $"Unable to get genres: {ex.Message}" });
             }
             return Results.Json(artistRepo.GetGenresForUser(username));
         }
@@ -77,13 +77,13 @@ namespace MusicAPI.Handlers
             }
             catch (Exception ex)
             {
-                return Results.BadRequest($"Unable to get songs: {ex.Message}");
+                return Results.BadRequest(new { Error = $"Unable to get songs: {ex.Message}" });
             }
             return Results.Json(artistRepo.GetSongsForUser(username));
 
         }
 
-        public static IResult GetArtists(HttpContext context, IArtistRepository artistRepo, string? name, int? amountPerPage, int? pageNumber)
+        public static IResult GetArtists(HttpContext context, IArtistRepository artistRepo, string? name, string? amountPerPage, string? pageNumber)
         {
             try
             {
@@ -91,12 +91,12 @@ namespace MusicAPI.Handlers
             }
             catch (Exception ex)
             {
-                return Results.BadRequest(new { Message = $"Unable to get artists: {ex.Message}" });
+                return Results.BadRequest(new { Error = $"Unable to get artists: {ex.Message}" });
             }
             return Results.Json(artistRepo.GetArtists(name, amountPerPage, pageNumber));
         }
 
-        public static IResult GetGenres(HttpContext context, IArtistRepository artistRepo, string? title, int? amountPerPage, int? pageNumber)
+        public static IResult GetGenres(HttpContext context, IArtistRepository artistRepo, string? title, string? amountPerPage, string? pageNumber)
         {
             try
             {
@@ -104,12 +104,12 @@ namespace MusicAPI.Handlers
             }
             catch (Exception ex)
             {
-                return Results.BadRequest($"Unable to get genres: {ex.Message}");
+                return Results.BadRequest(new { Error = $"Unable to get genres: {ex.Message}" });
             }
             return Results.Json(artistRepo.GetGenres(title, amountPerPage, pageNumber));
         }
 
-        public static IResult GetSongs(HttpContext context, IArtistRepository artistRepo, string? name, int? amountPerPage, int? pageNumber)
+        public static IResult GetSongs(HttpContext context, IArtistRepository artistRepo, string? name, string? amountPerPage, string? pageNumber)
         {
             try
             {
@@ -117,7 +117,7 @@ namespace MusicAPI.Handlers
             }
             catch (Exception ex)
             {
-                return Results.BadRequest($"Unable to get songs: {ex.Message}");
+                return Results.BadRequest(new { Error = $"Unable to get songs: {ex.Message}" });
             }
             return Results.Json(artistRepo.GetSongs(name, amountPerPage, pageNumber));
 

--- a/MusicAPI/Repositories/IArtistRepository.cs
+++ b/MusicAPI/Repositories/IArtistRepository.cs
@@ -227,13 +227,13 @@ namespace MusicAPI.Repositories
             }
 
             // Show all artists
-            if (name is null && amountPerPage is null && pageNumber is null)
+            if (string.IsNullOrEmpty(name)&& string.IsNullOrEmpty(amountPerPage)&& string.IsNullOrEmpty(pageNumber))
             {
                 return artists;
             }
 
             // Show a filtered list       
-            if (name is not null)
+            if (!string.IsNullOrEmpty(name))
             {
                 artists = artists
                         .Where(a => a.Name.ToUpper().StartsWith(name.ToUpper()))
@@ -242,19 +242,20 @@ namespace MusicAPI.Repositories
 
             // Pagination
             // check if amountPerPage & pageNumber are integers, otherwise return bad request
-            // if pageNumber = 0 we assume user meant = 1
-            // if amountPerPage = 0 we set default = 10
-            if (pageNumber == "0") pageNumber = "1";
-            if (amountPerPage == "0") amountPerPage = "10"; 
-            if (amountPerPage is not null || pageNumber is not null)
+            if (!string.IsNullOrEmpty(amountPerPage) || !string.IsNullOrEmpty(pageNumber))
             {
-                int parsedAmountPerPage = 10; //sets default value if only pageNumber not null
-                if (amountPerPage is not null && !int.TryParse(amountPerPage.ToString(), out parsedAmountPerPage))
+                // if one parameter is 0 or missing we set default value (we got here so at least one parameter is not missing)
+                if (pageNumber == "0" || string.IsNullOrEmpty(pageNumber)) pageNumber = "1";
+                if (amountPerPage == "0" || string.IsNullOrEmpty(amountPerPage)) amountPerPage = "10";
+
+                int parsedPageNumber = 1; //sets default value for parsed if this parameter was missing
+                int parsedAmountPerPage = 10; //sets default value for parsed if this parameter was missing
+
+                if (!int.TryParse(amountPerPage, out parsedAmountPerPage))
                 {
                     throw new Exception($"{nameof(amountPerPage)} måste vara en integer");
                 }
-                int parsedPageNumber = 1; //sets default value if only amountPerPage not null
-                if (pageNumber is not null && !int.TryParse(pageNumber.ToString(), out parsedPageNumber))
+                if (!int.TryParse(pageNumber, out parsedPageNumber))
                 {
                     throw new Exception($"{nameof(pageNumber)} måste vara en integer");
                 }
@@ -262,6 +263,7 @@ namespace MusicAPI.Repositories
                 int skipAmount = parsedAmountPerPage * (parsedPageNumber - 1);
                 int numberOfPages = (int)Math.Ceiling((decimal)artists.Count / parsedAmountPerPage);
                 int amountOnThisPage = parsedPageNumber < numberOfPages ? parsedAmountPerPage : artists.Count % parsedAmountPerPage;
+                if (artists.Count == parsedAmountPerPage) amountOnThisPage = parsedAmountPerPage; //special case that went wrong!
 
                 artists = artists
                  .Skip(skipAmount)
@@ -291,14 +293,14 @@ namespace MusicAPI.Repositories
             }
 
             // Show all genres
-            if (title is null && amountPerPage is null && pageNumber is null)
+            if (string.IsNullOrEmpty(title) && string.IsNullOrEmpty(amountPerPage) && string.IsNullOrEmpty(pageNumber))
             {
                 return genres;
             }
 
 
             // Show a filtered list       
-            if (title is not null)
+            if (!string.IsNullOrEmpty(title))
             {
                 genres = genres
                         .Where(a => a.Title.ToUpper().Contains(title.ToUpper()))
@@ -307,19 +309,20 @@ namespace MusicAPI.Repositories
 
             // Pagination
             // check if amountPerPage & pageNumber are integers, otherwise return bad request
-            // if pageNumber = 0 we assume user meant = 1
-            // if amountPerPage = 0 we set default = 10
-            if (pageNumber == "0") pageNumber = "1";
-            if (amountPerPage == "0") amountPerPage = "10";
-            if (amountPerPage is not null || pageNumber is not null)
+            if (!string.IsNullOrEmpty(amountPerPage) || !string.IsNullOrEmpty(pageNumber))
             {
-                int parsedAmountPerPage = 10; //sets default value if only pageNumber not null
-                if (amountPerPage is not null && !int.TryParse(amountPerPage.ToString(), out parsedAmountPerPage))
+                // if one parameter is 0 or missing we set default value (we got here so at least one parameter is not missing)
+                if (pageNumber == "0" || string.IsNullOrEmpty(pageNumber)) pageNumber = "1";
+                if (amountPerPage == "0" || string.IsNullOrEmpty(amountPerPage)) amountPerPage = "10";
+
+                int parsedPageNumber = 1; //sets default value if only amountPerPage wasn't missing
+                int parsedAmountPerPage = 10; //sets default value if only pageNumber wasn't missing
+
+                if (!int.TryParse(amountPerPage, out parsedAmountPerPage))
                 {
                     throw new Exception($"{nameof(amountPerPage)} måste vara en integer");
                 }
-                int parsedPageNumber = 1; //sets default value if only amountPerPage not null
-                if (pageNumber is not null && !int.TryParse(pageNumber.ToString(), out parsedPageNumber))
+                if (!int.TryParse(pageNumber, out parsedPageNumber))
                 {
                     throw new Exception($"{nameof(pageNumber)} måste vara en integer");
                 }
@@ -327,6 +330,7 @@ namespace MusicAPI.Repositories
                 int skipAmount = parsedAmountPerPage * (parsedPageNumber - 1);
                 int numberOfPages = (int)Math.Ceiling((decimal)genres.Count / parsedAmountPerPage);
                 int amountOnThisPage = parsedPageNumber < numberOfPages ? parsedAmountPerPage : genres.Count % parsedAmountPerPage;
+                if (genres.Count == parsedAmountPerPage) amountOnThisPage = parsedAmountPerPage; //special case that went wrong!
 
                 genres = genres
                  .Skip(skipAmount)
@@ -358,13 +362,13 @@ namespace MusicAPI.Repositories
             }
 
             // Show all songs
-            if (name is null && amountPerPage is null && pageNumber is null)
+            if (string.IsNullOrEmpty(name)&& string.IsNullOrEmpty(amountPerPage)&& string.IsNullOrEmpty(pageNumber))
             {
                 return songs;
             }
 
             // Show a filtered list       
-            if (name is not null)
+            if (!string.IsNullOrEmpty(name))
             {
                 songs = songs
                         .Where(a => a.Name.ToUpper().Contains(name.ToUpper()))
@@ -372,20 +376,21 @@ namespace MusicAPI.Repositories
             }
 
             // Pagination
-            // check if amountPerPage & pageNumber are integers, otherwise return bad request
-            // if pageNumber = 0 we assume user meant = 1
-            // if amountPerPage = 0 we set default = 10
-            if (pageNumber == "0") pageNumber = "1";
-            if (amountPerPage == "0") amountPerPage = "10";
+            // check if amountPerPage & pageNumber are integers, otherwise return bad request           
             if (!string.IsNullOrEmpty(amountPerPage) || !string.IsNullOrEmpty(pageNumber))
             {
-                int parsedAmountPerPage = 10; //sets default value if only pageNumber not null
-                if (amountPerPage is not null && !int.TryParse(amountPerPage.ToString(), out parsedAmountPerPage))
+                // if one parameter is 0 or missing we set default value (we got here so at least one parameter is not missing)
+                if (pageNumber == "0" || string.IsNullOrEmpty(pageNumber)) pageNumber = "1";
+                if (amountPerPage == "0" || string.IsNullOrEmpty(amountPerPage)) amountPerPage = "10";
+
+                int parsedPageNumber = 1; //sets default value if only amountPerPage is not missing
+                int parsedAmountPerPage = 10; //sets default value if only pageNumber is not missing
+
+                if (!int.TryParse(amountPerPage, out parsedAmountPerPage))
                 {
                     throw new Exception($"{nameof(amountPerPage)} måste vara en integer");
                 }
-                int parsedPageNumber = 1; //sets default value if only amountPerPage not null
-                if (pageNumber is not null && !int.TryParse(pageNumber.ToString(), out parsedPageNumber))
+                if (!int.TryParse(pageNumber, out parsedPageNumber))
                 {
                     throw new Exception($"{nameof(pageNumber)} måste vara en integer");
                 }
@@ -393,6 +398,7 @@ namespace MusicAPI.Repositories
                 int skipAmount = parsedAmountPerPage * (parsedPageNumber - 1);
                 int numberOfPages = (int)Math.Ceiling((decimal)songs.Count / parsedAmountPerPage);
                 int amountOnThisPage = parsedPageNumber < numberOfPages ? parsedAmountPerPage : songs.Count % parsedAmountPerPage;
+                if (songs.Count == parsedAmountPerPage) amountOnThisPage = parsedAmountPerPage; //special case that went wrong!
 
                 songs = songs
                  .Skip(skipAmount)

--- a/MusicAPITests/ArtistRepositoryTests.cs
+++ b/MusicAPITests/ArtistRepositoryTests.cs
@@ -196,7 +196,34 @@ namespace MusicAPITests
             context.SaveChanges();
 
             // Act
-            var result = artistHelper.GetArtists("", "0", "0");
+            var result = artistHelper.GetArtists("", "", "");
+
+            // Assert
+            Assert.IsNotNull(result);
+            Assert.AreEqual(2, result.Count());
+            Assert.IsTrue(result.Any(a => a.Name == artist1.Name));
+            Assert.IsTrue(result.Any(a => a.Name == artist2.Name));
+            Assert.IsTrue(result.Any(a => a.Description == artist1.Description));
+            Assert.IsTrue(result.Any(a => a.Description == artist2.Description));
+        }
+        [TestMethod]
+        public void GetArtists_GetsArtistsFromDbWithSearchQuery()
+        {
+            // Arrange 
+            DbContextOptions<ApplicationContext> options = new DbContextOptionsBuilder<ApplicationContext>()
+                .UseInMemoryDatabase("TestDb_GetArtistsWithSearchQuery")
+                .Options;
+            ApplicationContext context = new ApplicationContext(options);
+            DbArtistRepository artistHelper = new DbArtistRepository(context);
+
+            Artist artist1 = new Artist() { Name = "Test_Artist1", Description = "Test_Description1" };
+            Artist artist2 = new Artist() { Name = "Test_Artist2", Description = "Test_Description2" };
+
+            context.Artists.AddRange(artist1, artist2);
+            context.SaveChanges();
+
+            // Act
+            var result = artistHelper.GetArtists("T", "2", "1");
 
             // Assert
             Assert.IsNotNull(result);
@@ -224,7 +251,34 @@ namespace MusicAPITests
             context.SaveChanges();
 
             // Act
-            var result = artistHelper.GetGenres("", "0", "0");
+            var result = artistHelper.GetGenres("", "", "");
+
+            // Assert
+            Assert.IsNotNull(result);
+            Assert.AreEqual(2, result.Count());
+            Assert.IsTrue(result.Any(a => a.Title == genre1.Title));
+            Assert.IsTrue(result.Any(a => a.Title == genre2.Title));
+
+        }
+
+        [TestMethod]
+        public void GetGenres_GetsGenresFromDbWithSearchQuery()
+        {
+            // Arrange 
+            DbContextOptions<ApplicationContext> options = new DbContextOptionsBuilder<ApplicationContext>()
+                .UseInMemoryDatabase("TestDb_GetGenresWithSearchQuery")
+                .Options;
+            ApplicationContext context = new ApplicationContext(options);
+            DbArtistRepository artistHelper = new DbArtistRepository(context);
+
+            Genre genre1 = new Genre() { Title = "Test_genre1" };
+            Genre genre2 = new Genre() { Title = "Test_genre2" };
+
+            context.Genres.AddRange(genre1, genre2);
+            context.SaveChanges();
+
+            // Act
+            var result = artistHelper.GetGenres("T", "2", "1");
 
             // Assert
             Assert.IsNotNull(result);
@@ -250,7 +304,9 @@ namespace MusicAPITests
                 Artist = new Artist { Name = "TestArtist1", Description = "TestDesc1" },
                 Genre = new Genre { Title = "TestGenre1" }
             };
-            Song song2 = new Song() { Name = "Test_song2",
+            Song song2 = new Song()
+            {
+                Name = "Test_song2",
                 Artist = new Artist { Name = "TestArtist2", Description = "TestDesc2" },
                 Genre = new Genre { Title = "TestGenre2" }
             };
@@ -259,7 +315,7 @@ namespace MusicAPITests
             context.SaveChanges();
 
             // Act
-            var result = artistHelper.GetSongs("", "0", "0");
+            var result = artistHelper.GetSongs("", "", "");
 
             // Assert
             Assert.IsNotNull(result);
@@ -268,6 +324,42 @@ namespace MusicAPITests
             Assert.IsTrue(result.Any(a => a.Name == song2.Name));
 
         }
-        // kolla även om jag skickar sökning i GEt-metoden
+        [TestMethod]
+        public void GetSongs_GetsSongsFromDbWithSearchQuery()
+        {
+            // Arrange 
+            DbContextOptions<ApplicationContext> options = new DbContextOptionsBuilder<ApplicationContext>()
+                .UseInMemoryDatabase("TestDb_GetSongsWithSearchQuery")
+                .Options;
+            ApplicationContext context = new ApplicationContext(options);
+            DbArtistRepository artistHelper = new DbArtistRepository(context);
+
+            Song song1 = new Song()
+            {
+                Name = "Test_song1",
+                Artist = new Artist { Name = "TestArtist1", Description = "TestDesc1" },
+                Genre = new Genre { Title = "TestGenre1" }
+            };
+            Song song2 = new Song()
+            {
+                Name = "Test_song2",
+                Artist = new Artist { Name = "TestArtist2", Description = "TestDesc2" },
+                Genre = new Genre { Title = "TestGenre2" }
+            };
+
+            context.Songs.AddRange(song1, song2);
+            context.SaveChanges();
+
+            // Act
+            var result = artistHelper.GetSongs("T", "2", "1");
+
+            // Assert
+            Assert.IsNotNull(result);
+            Assert.AreEqual(2, result.Count());
+            Assert.IsTrue(result.Any(a => a.Name == song1.Name));
+            Assert.IsTrue(result.Any(a => a.Name == song2.Name));
+
+        }
+        
     }
 }


### PR DESCRIPTION
*Added
GetGenres_GetsGenresFromDbWithSearchQuery
GetSongs_GetsSongsFromDbWithSearchQuery 
GetArtists_GetsArtistsFromDbWithSearchQuery
*As a result of above I needed to correct repo methods that use them (Connect user to song etc) which returned nothing when amountPerPage was equal result.Count()
* Connect-methods take in string not int for pageNumber and amountPerPage now and the error control should be slitghly better
* Changed in APIArtistHandler so all Results.BadRequests return error message in json-format